### PR TITLE
General dashboard section & more dashboards

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,14 @@ A collection of Real-time data dashboards related to Ethereum
 ## General Dashboards
 
 * [AlphaDay](https://app.alphaday.com/)
+* [Rotki](https://rotki.com/)
 
 ## Ecosystem Health Dashboards
 
 * [Project Sunshine](https://ethsunshine.com)
 * [NodeWatch](https://nodewatch.io)
 * [Miga Labs Crawler](https://migalabs.es/crawler/dashboard)
+* [Ethereum Nodes Statistics](https://ethernodes.org/)
 
 ## Staking Dashboards
 
@@ -21,6 +23,7 @@ A collection of Real-time data dashboards related to Ethereum
 * [Client Diversity.org](https://clientdiversity.org)
 * [Ethereum Pools.info](https://ethereumpools.info/d/ox1NIwf7k/ethereumpools-public?orgId=1&kiosk&refresh=5m)
 * [EthSta.com](https://ethsta.com)
+* [Beaconchain](https://beaconcha.in)
 
 ## Monetary Policy Dashboards
 
@@ -42,3 +45,7 @@ A collection of Real-time data dashboards related to Ethereum
 
 * [Hildobby's beacon chain deposit dashboard](https://dune.com/hildobby/ETH2-Deposits)
 * [Chainanalytics MEV](https://dune.com/ChainsightAnalytics/mev-after-ethereum-merge)
+
+## NFTs
+
+* [icy.tools](https://icy.tools/)

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ A collection of Real-time data dashboards related to Ethereum
 **Pull Requests are encouraged and welcome :)**
 
 
-## News Dashboards
+## General Dashboards
 
-* [Alpha Day](https://app.alphaday.com/)
+* [AlphaDay](https://app.alphaday.com/)
 
 ## Ecosystem Health Dashboards
 


### PR DESCRIPTION
Several proposals:

* I think classifying Alphaday into "news" is stretching it too thin, and I think a "General", or "Aggregated" dashboard section is better.
* Rotki should go in there too, since it has all types of information.
* Added extra NFT section with icy.tools
* Added extra dashboards: beaconchain, ethernodes


Thought of adding an extra financial header, for messari, nansen- but didn't fit in perfectly so just left it out.